### PR TITLE
Update head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -94,7 +94,6 @@
 	{{ template "_internal/opengraph.html" . }}
 	{{ template "_internal/twitter_cards.html" . }}
 	{{ template "_internal/schema.html" . }}
-	{{/*  {{ template "_internal/google_news.html" . }}  */}}
 	{{ template "_internal/google_analytics.html" . }}
 	{{ template "_internal/disqus.html" . }}
 	{{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -96,7 +96,6 @@
 	{{ template "_internal/schema.html" . }}
 	{{/*  {{ template "_internal/google_news.html" . }}  */}}
 	{{ template "_internal/google_analytics.html" . }}
-	{{ template "_internal/google_analytics_async.html" . }}
 	{{ template "_internal/disqus.html" . }}
 	{{- end -}}
 </head>


### PR DESCRIPTION
Removal of google async due to build shows:

WARN  _internal/google_analytics_async.html is no longer supported by Google and will be removed in a future version of Hugo