### PR TITLE
Disqus fix

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,12 +14,7 @@
 	{{ partial "video-layout.html" . }}
 {{ end }}
 
-{{/*  Disqus  */}}
-{{- with .Params.DisqusShortname -}}
-<div>
-	{{ template "_internal/disqus.html" . }}
-</div>
-{{ end }}
+{{ template "_internal/disqus.html" . }}
 
 {{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -97,6 +97,5 @@
 	{{/*  {{ template "_internal/google_news.html" . }}  */}}
 	{{ template "_internal/google_analytics.html" . }}
 	{{ template "_internal/google_analytics_async.html" . }}
-	{{ template "_internal/disqus.html" . }}
 	{{- end -}}
 </head>


### PR DESCRIPTION
Issue with positioing of the disqus code in header not required.

Also wrapper in single.html isn't needed already handled in the internal template.