### PR TITLE
Example site: fix error message when running with latest hugo version 0.152.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Changelog
-# Changelog
 
 All notable changes to this theme will be documented in this file.
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,4 +3,3 @@
 - [ ] Implement GDPR cookie consent.
 - [ ] Improve date localization for all languages.
 - [ ] Review and update documentation.
-

--- a/exampleSite/.gitignore
+++ b/exampleSite/.gitignore
@@ -1,0 +1,3 @@
+/public/
+/resources/_gen/
+.hugo_build.lock

--- a/exampleSite/content/contact/index.md
+++ b/exampleSite/content/contact/index.md
@@ -4,7 +4,6 @@ subtitle: "Insert subtitles"
 draft: false
 date: 2022-04-26T21:28:23+02:00
 lastmod: 2022-04-26T21:28:23+02:00
-draft: false
 
 resources:
   - name: featured-image

--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -174,4 +174,4 @@ other = "text-post"
 other = "von"
 
 [authorImageAlt]
-other = "Bilde des Autors"
+other = "Bild des Autors"

--- a/layouts/_shortcodes/gist.html
+++ b/layouts/_shortcodes/gist.html
@@ -1,0 +1,1 @@
+<script src="https://gist.github.com/{{ index .Params 0 }}/{{ index .Params 1 }}.js{{if len .Params | eq 3 }}?file={{ index .Params 2 }}{{end}}"></script>


### PR DESCRIPTION
When running example site with latest released hugo version 0.152.2, an error is thrown:


```
hugo v0.152.2-6abdacad3f3fe944ea42177844469139e81feda6+extended linux/amd64 BuildDate=2025-10-24T15:31:49Z VendorInfo=gohugoio

Built in 32 ms
Error: error building site: process: readAndProcessContent: "/home/andreas/arberia/exampleSite/content/contact/index.md:7:1": [6:1] mapping key "draft" already defined at [3:1]
   3 | draft: false
   4 | date: 2022-04-26T21:28:23+02:00
   5 | lastmod: 2022-04-26T21:28:23+02:00
>  6 | draft: false
       ^
   8 | resources:
   9 |   - name: featured-image
  10 |
```

This PR fixes that error.
This PR comes with some other minor improvements, too.